### PR TITLE
Make test suite actually exit with proper exit code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "preferGlobal": true,
   "bin": "./index.js",
   "scripts": {
-    "test": "./node_modules/.bin/_mocha --reporter spec -t 10000 test | bunyan",
+    "test": "./test/test.sh",
     "cov": "`npm bin`/istanbul cover --root . -x node_modules -x test --dir ./reports `npm bin`/_mocha -- --reporter spec -t 10000 test | bunyan",
     "coveralls": "npm run cov && node_modules/coveralls/bin/coveralls.js < reports/lcov.info"
   },

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -o pipefail
+
+./node_modules/.bin/_mocha --reporter spec -t 10000 test | bunyan


### PR DESCRIPTION
Current test suite always exits with zero because it's piped through
bunyan.  Since bunyan is always successful and it's the last command
on the pipe chain we get its exit code.

By moving the command into a shell script and setting the pipefail
option for bash we will exit with the proper exit code.  This means
that Travis CI will correctly determine test failures.