### PR TITLE
Fix the failing ignore_repo_name test.

### DIFF
--- a/test/git2consul_ignore_repo_name_test.js
+++ b/test/git2consul_ignore_repo_name_test.js
@@ -33,12 +33,12 @@ describe('ignore_repo_name', function() {
           var repo_config = git_utils.createRepoConfig();
           repo_config.source_root = "src/main/resources";
           repo_config.expand_keys = true;
-          repo.include_branch_name = false;
+          repo_config.include_branch_name = false;
           repo_config.ignore_repo_name = true;
           var repo = new Repo(repo_config);
           repo.init(function(err) {
             if (err) return done(err);
-            consul_utils.validateValue('user-service-dev/default.connection.pool.db.url', "jdbc:mysql://db-host:3306/user", function(err, value) {
+            consul_utils.validateValue('user-service-dev.properties/default.connection.pool.db.url', "jdbc:mysql://db-host:3306/user", function(err, value) {
               if (err) return done(err);
               done();
             });


### PR DESCRIPTION
Was trying to set the include_branch_name property on a variable that
didn't exist.  Which caused the test to fail with a syntax error.

Was using a property file but wasn't expecting the file extension to be
in the key path.