### PR TITLE
Append `/` character when fetching the kv

### DIFF
--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -308,7 +308,7 @@ var get_kvs = function(branch, file, cb) {
   logger.trace('Getting tree for key %s', key_name);
 
   // Load all sub-keys as a flattened tree of KV pairs
-  consul.kv.get({'key': key_name, token: token, recurse: true}, function(err, kvs, res) {
+  consul.kv.get({'key': key_name + '/', token: token, recurse: true}, function(err, kvs, res) {
     if (err) return cb('Failed to get tree for key ' + key_name + ' due to ' + err, undefined);
 
     var tree = []


### PR DESCRIPTION
otherwise the operation fetches keys which do not EXACTLY match the
request key. For example, having the following keys:

`foo/bar` & `foo-test/bar`

and fetching them with:

`consul.kv.get({'key': 'foo', recurse:true},
function(err,kvs,res) {console.log(kvs);});`

will return:

```
[ { LockIndex: 0,
    Key: 'foo/bar',
    Flags: 0,
    Value: 'test1',
    CreateIndex: 171,
    ModifyIndex: 171 },
  { LockIndex: 0,
    Key: 'foo-test/bar',
    Flags: 0,
    Value: 'test2',
    CreateIndex: 10,
    ModifyIndex: 10 } ]
```

this change will avoid that problem.