### PR TITLE
fix crash on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> This utility is **exactly** the same as [breser/git2consul](https://github.com/breser/git2consul) but it includes a small patch that fixes a crash on Windows.
+
 # git2consul
 
 [![Build Status](https://travis-ci.org/breser/git2consul.svg?branch=master)](https://travis-ci.org/breser/git2consul)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,8 @@ module.exports.validate_writeable_directory = function(dir) {
   }
 
   // Check whether this owner or group or anyone is allowed to write the directory.
-  var can_write = ((process.getuid() === stat.uid) && (stat.mode & 00200)) || // User is owner and owner can write.
+  var can_write = (!process.getuid) || // process.getuid() does not exist on windows
+                  ((process.getuid() === stat.uid) && (stat.mode & 00200)) || // User is owner and owner can write.
                   ((process.getgid() === stat.gid) && (stat.mode & 00020)) || // User is in group and group can write.
                   ((stat.mode & 00002)); // Anyone can write.
   if (!can_write) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "git2consul",
+  "name": "git2consul-windows",
   "description": "System for moving data from git to consul",
   "license": "Apache-2.0",
   "version": "0.12.13",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/Cimpress-MCP/git2consul.git"
+    "url": "git://github.com/andriniaina/git2consul-windows.git"
   },
   "dependencies": {
     "body-parser": "~1.4.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "git2consul-windows",
   "description": "System for moving data from git to consul",
   "license": "Apache-2.0",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "contributors": [
     {
       "name": "Ryan Breen",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     {
       "name": "Ryan Breen",
       "email": "rbreen@cimpress.com"
+    },
+    {
+      "name": "Andri Rakotomalala",
+      "email": "andriniaina@gmail.com"
     }
   ],
   "repository": {


### PR DESCRIPTION
Hello,
git2consul crashes on Windows because the function `process.getuid()` does not exist. With this fix, on Windows, we assume that the directory is always writable.