### PR TITLE
Add token authentication for webhook (GitLab first)

### DIFF
--- a/lib/git/hooks/webhook.js
+++ b/lib/git/hooks/webhook.js
@@ -79,6 +79,7 @@ function init_express(config) {
 // object to perform Git or Stash-specific functions.
 function create_webhook(config, repo, implementation) {
   var app = init_express(config);
+  var messageSend = 'ok';
 
   // We don't care what method is used, so use them all.
   ['get','post','put','delete'].forEach(function(verb) {
@@ -98,7 +99,7 @@ function create_webhook(config, repo, implementation) {
                 if (err) return logger.error(err);
               });
             }
-            return res.send('ok');
+            return res.send(messageSend);
           }
 
           for (var i=0; i<changes.length; ++i) {
@@ -119,11 +120,11 @@ function create_webhook(config, repo, implementation) {
           }
         } else {
           res.status(403);
-          return res.send('ko');
+          messageSend = 'ko';
         }
       }
 
-      res.send('ok');
+      res.send(messageSend);
     });
   });
 

--- a/lib/git/hooks/webhook.js
+++ b/lib/git/hooks/webhook.js
@@ -249,8 +249,8 @@ exports.gitlab = {
 
   isToken: function(req, config) {
     if (config.token && req.get("X-Gitlab-Token") ) {
-      var tokenHash = sha512(config.token).toString('hex');
-      if(req.get("X-Gitlab-Token") == tokenHash) {
+      var tokenHash = sha512(req.get("X-Gitlab-Token")).toString('hex');
+      if(tokenHash == config.token) {
         return true;
       } else {
         return false;

--- a/lib/git/hooks/webhook.js
+++ b/lib/git/hooks/webhook.js
@@ -7,6 +7,8 @@ var logger = require('../../logging.js');
 var Branch = require('../branch.js');
 var git_commands = require('../commands.js');
 
+var sha512 = require('sha512');
+
 // Create an object to map from host port to app.  Multiple hosts can be configured to listen
 // on the same port.
 var server_apps = {};
@@ -85,36 +87,39 @@ function create_webhook(config, repo, implementation) {
 
       /* istanbul ignore else */
       if (implementation.isValid(req)) {
-
-        logger.trace(util.inspect(req.body, {depth: 10}));
-
-        // Only pull changed branches
-        var changes = implementation.getHeadChanges(req);
-        if (changes.length === 0) {
-          logger.trace('No changes in a relevant branch. Checking and updating tags');
-          if (repo.repo_config.support_tags === true) {
-            repo.createNewTagsAsBranch(function(err, new_tags) {
-              if (err) return logger.error(err);
-            });
+        if(implementation.isToken(req, config)) {
+        
+          // Only pull changed branches
+          var changes = implementation.getHeadChanges(req);
+          if (changes.length === 0) {
+            logger.trace('No changes in a relevant branch. Checking and updating tags');
+            if (repo.repo_config.support_tags === true) {
+              repo.createNewTagsAsBranch(function(err, new_tags) {
+                if (err) return logger.error(err);
+              });
+            }
+            return res.send('ok');
           }
-          return res.send('ok');
-        }
 
-        for (var i=0; i<changes.length; ++i) {
-          var change = changes[i];
-          var to_hash = change.to_hash;
-          logger.info('Webhook noted change to branch %s of repo %s with commit id %s', change.branch, repo.name, change.to_hash);
+          for (var i=0; i<changes.length; ++i) {
+            var change = changes[i];
+            var to_hash = change.to_hash;
+            logger.info('Webhook noted change to branch %s of repo %s with commit id %s', change.branch, repo.name, change.to_hash);
 
-          // Update consul git branch
-          var branch = repo.branches[change.branch];
-          if (branch) {
-            branch.handleRefChange(change.to_hash, function(err) {
-              /* istanbul ignore next */
-              if (err) logger.error(err);
+            // Update consul git branch
+            var branch = repo.branches[change.branch];
+            if (branch) {
+              branch.handleRefChange(change.to_hash, function(err) {
+                /* istanbul ignore next */
+                if (err) logger.error(err);
 
-              logger.debug('Updates in branch %s of repo %s complete', change.branch, repo.name);
-            });
+                logger.debug('Updates in branch %s of repo %s complete', change.branch, repo.name);
+              });
+            }
           }
+        } else {
+          res.status(403);
+          return res.send('ko');
         }
       }
 
@@ -134,6 +139,10 @@ exports.github = {
 
   isValid: function(req) {
     return req && req.body && req.body.ref && req.body.head_commit && req.body.head_commit.id;
+  },
+
+  isToken: function(req, config) {
+    return true;
   },
 
   getHeadChanges: function(req) {
@@ -159,6 +168,10 @@ exports.stash = {
 
   isValid: function(req) {
     return req && req.body && req.body.refChanges;
+  },
+
+  isToken: function(req, config) {
+    return true;
   },
 
   getHeadChanges: function(req) {
@@ -201,6 +214,10 @@ exports.bitbucket = {
     return false;
   },
 
+  isToken: function(req, config) {
+    return true;
+  },
+
   getHeadChanges: function(req) {
     var changes = [];
     for (var i=0; i<req.body.commits.length; ++i) {
@@ -228,6 +245,18 @@ exports.gitlab = {
 
   isValid: function(req) {
     return req && req.body && req.body.ref && req.body.after;
+  },
+
+  isToken: function(req, config) {
+    if (config.token && req.get("X-Gitlab-Token") ) {
+      var tokenHash = sha512(config.token).toString('hex');
+      if(req.get("X-Gitlab-Token") == tokenHash) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    return true;
   },
 
   getHeadChanges: function(req) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "rimraf": "2.2.8",
     "underscore": "^1.8.0",
     "properties": "1.2.1",
-    "js-yaml": "^3.6.1"
+    "js-yaml": "^3.6.1",
+    "sha512": "^0.0.1"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
Can you add Token webhook management for security aspect ?
I'm not an expert in developpement but you can find my first solution. 
I only implement GitLab management but other can be added after.
I will work soon on GitHub too. 
For this an extra parameter must be added in hook definition "token" and it must be hashed in SHA 512
