### PR TITLE
fix bitbucket webhook handler to work with bitbucket >v5.4

### DIFF
--- a/lib/git/hooks/webhook.js
+++ b/lib/git/hooks/webhook.js
@@ -187,15 +187,8 @@ exports.bitbucket = {
   type: 'bitbucket',
 
   isValid: function(req) {
-
-    if (req && req.body && req.body.payload) {
-      try {
-        req.body = JSON.parse(req.body.payload);
-        return req.body && req.body.commits && req.body.commits.length;
-      /* istanbul ignore next */
-      } catch(e) {
-        // We don't care about a busted message.
-      }
+    if (req && req.body && req.body.changes && req.body.eventKey && req.body.eventKey === "repo:refs_changed") {
+      return req.body && req.body.changes && req.body.changes.length;
     }
 
     return false;
@@ -203,15 +196,13 @@ exports.bitbucket = {
 
   getHeadChanges: function(req) {
     var changes = [];
-    for (var i=0; i<req.body.commits.length; ++i) {
-      var commit = req.body.commits[i];
+    for (var i=0; i<req.body.changes.length; ++i) {
+      var change = req.body.changes[i];
 
-      // Only update if the head of a branch changed
-      /* istanbul ignore else */
-      if (commit.branch && (commit.parents.length !== 0) && commit.node) {
+      if (change.refId && (change.refId.indexOf('refs/heads/') === 0) && change.toHash) {
         changes.push({
-          'to_hash': commit.node,
-          'branch': commit.branch
+          'to_hash': change.toHash,
+          'branch': change.refId.substring(11)
         });
       }
     }


### PR DESCRIPTION
[Documentation for webhooks events](https://confluence.atlassian.com/bitbucketserver054/event-payload-939508609.html) which is new way of setting hooks.
This "webhook events" have been added in version 5.4 ([release notes](https://confluence.atlassian.com/bitbucketserver/bitbucket-server-5-4-release-notes-935388966.html)).

Older version of code worked with "POST Webhook", but I don't see how this code could have worked with `v5.0` Bitbucket for example ([doc](https://confluence.atlassian.com/bitbucketserver050/post-service-webhook-for-bitbucket-server-913475084.html)).

Also code for this old 4 years.

Should I change this code to work with "POST Webhooks" (new format) and new Webhook events or this is OK?