### PR TITLE
Added Ignore file name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,10 @@ Note :
 
 `ignore_repo_name` is a repo-level option that, when set to true the repository name would be omitted from the prefix.
 
+##### ignore_file_name (default: false)
+
+`ignore_file_name` is a repo-level option that, when set to true the file name would be omitted from the prefix.
+
 ##### ignore_file_extension (default: false)
 
 an `ignore_file_extension` is a repo-level option lets file names be ignored by consul while creating sub folder.

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -69,7 +69,9 @@ var create_key_name = function(branch, file, ref) {
       file = file.substr(0, file.lastIndexOf('.'));
     }
   }
-  key_parts.push(file);
+  if (branch.ignore_file_name) {
+      key_parts.push(file);
+  }
   return key_parts.join('/');
 };
 

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -69,7 +69,7 @@ var create_key_name = function(branch, file, ref) {
       file = file.substr(0, file.lastIndexOf('.'));
     }
   }
-  if (branch.ignore_file_name) {
+  if (!branch.ignore_file_name) {
       key_parts.push(file);
   }
   return key_parts.join('/');

--- a/lib/git/branch.js
+++ b/lib/git/branch.js
@@ -38,6 +38,7 @@ function Branch(repo_config, name) {
   Object.defineProperty(this, 'pending_callbacks', {value: [], writable: true});
   Object.defineProperty(this, 'ignore_file_extension', {value: repo_config['ignore_file_extension'] === true});
   Object.defineProperty(this, 'ignore_repo_name', {value: repo_config['ignore_repo_name'] === true});
+  Object.defineProperty(this, 'ignore_file_name', {value: repo_config['ignore_file_name'] === true});
 }
 
 Branch.prototype.clone = function(cb) {

--- a/test/git2consul_ignore_file_name_test.js
+++ b/test/git2consul_ignore_file_name_test.js
@@ -34,12 +34,12 @@ describe('ignore_file_name', function() {
                     repo_config.source_root = "src/main/resources";
                     repo_config.expand_keys = true;
                     repo_config.include_branch_name = false;
-                    repo_config.ignore_repo_name = true;
+                    repo_config.ignore_repo_name = false;
                     repo_config.ignore_file_name = true;
                     var repo = new Repo(repo_config);
                     repo.init(function(err) {
                         if (err) return done(err);
-                        consul_utils.validateValue('default.connection.pool.db.url', "jdbc:mysql://db-host:3306/user", function(err, value) {
+                        consul_utils.validateValue('test_repo/default.connection.pool.db.url', "jdbc:mysql://db-host:3306/user", function(err, value) {
                             if (err) return done(err);
                             done();
                         });

--- a/test/git2consul_ignore_file_name_test.js
+++ b/test/git2consul_ignore_file_name_test.js
@@ -1,0 +1,52 @@
+var should = require('should');
+var _ = require('underscore');
+
+var path = require('path');
+
+// We want this above any git2consul module to make sure logging gets configured
+require('./git2consul_bootstrap_test.js');
+
+var mkdirp = require('mkdirp');
+
+var consul_utils = require('./utils/consul_utils.js');
+
+var Repo = require('../lib/git/repo.js');
+var git_utils = require('./utils/git_utils.js');
+
+var git_commands = require('../lib/git/commands.js');
+
+describe('ignore_file_name', function() {
+
+    it ('should create folders on consul without the file name prefix', function(done) {
+
+        // Create a remote git repo.  Then, init a Repo object with property file and validate
+        // that keys are in the appropriate place in the Consul KV store without the file name prefix.
+        git_commands.init(git_utils.TEST_REMOTE_REPO, function(err) {
+            if (err) return done(err);
+
+            mkdirp(git_utils.TEST_REMOTE_REPO + "src/main/resources", function(cb) {
+                if (err) return done(err);
+
+                git_utils.addFileToGitRepo("src/main/resources/user-service-dev.properties", "default.connection.pool.db.url=jdbc:mysql://db-host:3306/user", "User property file for dev environment added.", function(err) {
+                    if (err) return done(err);
+
+                    var repo_config = git_utils.createRepoConfig();
+                    repo_config.source_root = "src/main/resources";
+                    repo_config.expand_keys = true;
+                    repo_config.include_branch_name = false;
+                    repo_config.ignore_repo_name = true;
+                    repo_config.ignore_file_name = true;
+                    var repo = new Repo(repo_config);
+                    repo.init(function(err) {
+                        if (err) return done(err);
+                        consul_utils.validateValue('default.connection.pool.db.url', "jdbc:mysql://db-host:3306/user", function(err, value) {
+                            if (err) return done(err);
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
Added Ignore filename option,
`ignore_file_name` is a repo-level option that, when set to true the file name would be omitted from the prefix.
Usage example :

```javascript
{
  "version": "1.0",
  "repos" : [{
    "name" : "sample_configuration",
    "url" : "https://github.com/ryanbreen/git2consul_data.git",
    "ignore_file_extension" : true,
    "ignore_file_name" : true,
    "branches" : ["dev"],
    "hooks": [{
      "type" : "polling",
      "interval" : "1"
    }]
  }]
}
```



